### PR TITLE
New 2021 rules which remove the department name from the cover page

### DIFF
--- a/cover.tex
+++ b/cover.tex
@@ -7,7 +7,9 @@
 %% Modified by João Paulo Barraca <jpbarraca@ua.pt>
 %% Modified by Filipe Manco <filipe.manco@ua.pt>
 
-\documentclass[11pt,twoside,a4paper]{report}
+% Remove 'coverdepname' parameter to remove department name from cover pages
+% Add 'final' parameter to remove "DOCUMENTO PROVISÓRIO" from cover page
+\documentclass[11pt,twoside,a4paper,coverdepname]{report}
 
 %%% This file is a template for the cover of your
 %%%  thesis.

--- a/matter.tex
+++ b/matter.tex
@@ -1,7 +1,7 @@
 %%!TEX encoding = UTF-8 Unicode
 
 % According to UA rules, font size should range from 10 to 12pt.
-\documentclass[11pt,a4paper,openright,final,twoside,onecolumn]{memoir}
+\documentclass[11pt,a4paper,openright,twoside,onecolumn]{memoir}
 
 \listfiles
 \fixpdflayout

--- a/uaThesisTemplate.sty
+++ b/uaThesisTemplate.sty
@@ -58,6 +58,12 @@
 \DeclareOption{final}{\ua@final@true}
 
 %
+% New 2021 rules which remove the department name from the cover page
+%
+\newif\ifua@coverdepname@\ua@coverdepname@true
+\DeclareOption{coverdepname}{\ua@coverdepname@false}
+
+%
 % color of the cover page top bar
 % (pantone approximations according to http://goffgrafix.com/pantone-rgb-100.php)
 %
@@ -275,8 +281,12 @@
 \def\ua@above#1#2{\rlap{\smash{\raise 10pt\hbox{\ua@font@size1\textsf{#1}}}}\hbox{\ua@font@size1\textsf{#2}}}
 \def\ua@below#1#2{\rlap{\smash{\lower 10pt\hbox{\ua@font@size1\textsf{#2}}}}\hbox{\ua@font@size1\textsf{#1}}}
 \long\def\HEADER#1#2{\vspace*{5mm}\noindent\ua@font@size1\rlap{\parbox{\textwidth}{%
+    \ifua@coverdepname@
+    \ua@font@size1\hspace*{77mm}#1\textsf{\vspace*{0.7mm}\textbf{Universidade de Aveiro}}\space\space
+    \else
     \ua@font@size1\hspace*{77mm}#1\textsf{\textbf{Universidade de Aveiro}}\space\space
       \ua@above{\ua@textA}{\ua@textB}%
+    \fi
     \iffalse
       \hrule width \textwidth height .3pt depth 0mm\relax
     \else
@@ -297,8 +307,12 @@
 
 
 \long\def\INNERHEADER#1#2{\vspace*{5mm}\noindent\ua@font@size1\rlap{\parbox{\textwidth}{%
+    \ifua@coverdepname@
+    \ua@font@size1\hspace*{77mm}#1\textsf{\vspace*{0.7mm}\textbf{Universidade de Aveiro}}\space\space
+    \else
     \ua@font@size1\hspace*{77mm}#1\textsf{\textbf{Universidade de Aveiro}}\space\space
       \ua@above{\ua@textA}{\ua@textB}%
+    \fi
     \iffalse
       \hrule width \textwidth height .3pt depth 0mm\relax
     \else


### PR DESCRIPTION
On January 14th Sr. José sent an email informing the new dissertation template norms:

> Para a versão final da dissertação, foi recentemente deliberado que na capa e na folha seguinte só deve ser mencionado “Universidade de Aveiro” sem a indicação do departamento.
> A primeira página correta é

![image](https://user-images.githubusercontent.com/20357938/106039335-ec5e5000-60d0-11eb-8f34-00f302641fa7.png)

> A segunda página correta é

![image](https://user-images.githubusercontent.com/20357938/106039393-fbdd9900-60d0-11eb-9c03-778cbdebefea.png)

> Por favor consultem a página das normas e modelos: [https://www.ua.pt/pt/sga/page/12810](https://www.ua.pt/pt/sga/page/12810)

I added a `coverdepname` class option which enables the department name. I don't know if this norm will continue for the next years, and the complete remove of the department name didn't seem fit (I actually prefer the cover with it).

The second page didn't match the picture sent by Sr. José, but consulting the document in the UA norm [webpage](https://www.ua.pt/pt/sga/page/12810), it matches the current state of the template, whereby not changed. 

The `final` class option didn't seem to be working in `matter.tex`. I moved it to the `cover.tex` file document class where it seems to be actually detected.