### PR TITLE
Fix department name on cover

### DIFF
--- a/cover.tex
+++ b/cover.tex
@@ -9,7 +9,7 @@
 
 % Remove 'coverdepname' parameter to remove department name from cover pages
 % Add 'final' parameter to remove "DOCUMENTO PROVISÓRIO" from cover page
-\documentclass[11pt,twoside,a4paper,coverdepname]{report}
+\documentclass[11pt,twoside,a4paper]{report}
 
 %%% This file is a template for the cover of your
 %%%  thesis.

--- a/uaThesisTemplate.sty
+++ b/uaThesisTemplate.sty
@@ -169,8 +169,8 @@
   \def\ua@textD{}%
 }
 \DeclareOption{deti}{%
-  \def\ua@textA{}%
-  \def\ua@textB{}%
+  \def\ua@textA{Departamento de Eletr\'{o}nica,}%
+  \def\ua@textB{Telecomunica\c{c}\~{o}es e Inform\'{a}tica}%
   \def\ua@textC{}%
   \def\ua@textD{}%
 }


### PR DESCRIPTION
Fixes #26 

Remove departed name from cover page + reverted a9f968a since it was leading to this (on the first page after the cover):

![bug](https://user-images.githubusercontent.com/23409890/137473830-613c33d7-16c3-479b-a4da-dba8464095be.png)