### PR TITLE
Fixed the issue with the appendix lack of designation

### DIFF
--- a/matter.tex
+++ b/matter.tex
@@ -216,6 +216,12 @@
 %\addtolength{\parskip}{0.5\baselineskip}
 \linespread{1.5}
 
+\newcommand\mainmatterWithoutReset
+{\edef\temppagenumber{\arabic{page}}%
+  \mainmatter
+  \setcounter{page}{\temppagenumber}%
+}
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Document begins here
@@ -358,8 +364,11 @@
 % Load appendix
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%\include{appendix-a}
-%\include{appendix-b}
-%\include{appendix-c}
+\mainmatterWithoutReset
+\appendix
+
+% \include{appendix-a}
+% \include{appendix-b}
+% \include{appendix-c}
 
 \end{document}


### PR DESCRIPTION
Signed-off-by: oEscal <pedroescaleira@hotmail.com>

Currently, there is a minor issue with the appendixes' designation. The expectation would be that their designation to be alphabetic, i.e., the first appendix chapter be represented by the letter A, the second by B, and so on. However, both in the table of contents and in each chapter appear without any letter (or number, for that matter). This problem also impacts the sections' or figures' numbering (in the current template, sections don't have numeration, and figures start their numeration from the beginning).
This problem stems from using the command `\backmatter` at the end of `matter.tex`. This command removes the References' chapter numbering but ends up removing all numeration from that point on. We could fix this using the [`\mainmatter` command](https://latexref.xyz/_005cfrontmatter-_0026-_005cmainmatter-_0026-_005cbackmatter.html), but that would start the page numbering all over again.

With all this in mind, this pull request fixes this issue with the creation of the `\mainmatterWithoutReset`, with a behavior similar to `\mainmatter`, but without resetting the page numbering.

 - Current behavior:
   1. Table of contents with two appendix chapters:
        ![image](https://user-images.githubusercontent.com/40316784/213877250-3a109696-3e4a-4d16-b27e-7efbbcf3bdfe.png)

    2. One of the appendix chapters:
        ![image](https://user-images.githubusercontent.com/40316784/213877282-117359e3-758c-4686-91b2-0fd3dff5bcc7.png)


Expected behavior:
 - Current behavior:
   1. Table of contents with two appendix chapters:
        ![image](https://user-images.githubusercontent.com/40316784/213877371-9effc8cb-e385-45db-ab77-fd3746d2abb2.png)


    2. One of the appendix chapters:
        ![image](https://user-images.githubusercontent.com/40316784/213877398-2e565490-3928-4475-8f78-f7a15c320e4e.png)
