### PR TITLE
Grant text was rolling over to the next page

### DIFF
--- a/uaThesisTemplate.sty
+++ b/uaThesisTemplate.sty
@@ -345,7 +345,7 @@
       \ua@below{\ua@textC}{\ua@textD}}}\par
   \ifdefined \ciMAPProgram
   \ua@font@size1\vspace*{-10.8mm}\noindent\hspace*{10.5mm}\includegraphics[height=15mm]{figs/map}
-  \else    
+  \else
   \ua@font@size1\vspace*{-10.8mm}\noindent\hspace*{63.56mm}\includegraphics[height=15.88mm]{figs/uaLogoNew}%
   \fi%
 %    \ifua@final@\else
@@ -501,11 +501,11 @@
   \TitlePage
      \HEADER{\BAR} % the \FIG{} is optional
            {\ciThesisYear}
-   
+
 	\TITLE{\DISPLAYAUTHOR}{\selectlanguage{portuguese}\ciTitlePT\newline}
 	\TITLE{ }{\selectlanguage{english}\ciTitleEN\newline}
-	 
-	
+
+
   \EndTitlePage
   \titlepage\ \endtitlepage % empty page
 
@@ -526,7 +526,7 @@
 
 	\TITLE{\DISPLAYAUTHOR}{\selectlanguage{portuguese}\ciTitlePT\newline}
 	\TITLE{ }{\selectlanguage{english}\ciTitleEN\newline}
-	
+
   \EndTitlePage
   \titlepage\ \endtitlepage % empty page
 \fi
@@ -545,8 +545,8 @@
 
 	\TITLE{\DISPLAYAUTHOR}{\selectlanguage{portuguese}\ciTitlePT\newline}
 	\TITLE{ }{\selectlanguage{english}\ciTitleEN\newline}
-	
-	
+
+
   \vspace*{25mm}
   \TEXT{}{%
 \noindent%
@@ -555,17 +555,17 @@ Proposta de Tese%
 \else
  \ifdefined \ciDocumentTypeThesis%
 Tese%
- \else 
+ \else
     \ifdefined \ciDocumentTypeDissertation%
 Disserta\c c\~ao%
     \fi %
   \fi%
-\fi%  
+\fi%
 ~apresentada \`a Universidade de Aveiro para cumprimento dos requisitos necess\'arios \`a
 \ifdefined \ciDocumentTypeThesisProposal%
-conclusão da unidade curricular Proposta de Tese, condi\c c\~ao necess\'aria para  
+conclusão da unidade curricular Proposta de Tese, condi\c c\~ao necess\'aria para
 \fi%
-obten\c c\~ao do grau de {\ciDegreeTitle} 
+obten\c c\~ao do grau de {\ciDegreeTitle}
 \ifdefined \ciMAPProgram%
 no âmbito do Programa de Doutoramento
 \fi%
@@ -574,7 +574,7 @@ em {\ciDegreeName}
  das Universidades do Minho, Aveiro e Porto (MAP-\ciMAPProgram)
 \fi%
 , realizada sob a orienta\c c\~ao cient\'ifica do Doutor {\ciSupervisorName}, Professor {\ciSupervisorTitle} do {\ua@textA} {\ua@textB} da Universidade de Aveiro{\yourSecondSupervisor}.}
-    \vspace{120mm}
+    \vspace{95mm}
 \ifdefined \ciGrantFirst
     \SPONSOR{}{
           \ifdefined \ciGrantFirst%


### PR DESCRIPTION
Funding/Grant text is rolling over to the next page on many occasions. A quick fix by adjusting the respective \vspace to a saner value.