### PR TITLE
Add branch name to `git subtree pull`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $ mkdir mythesis
 $ git init .
 $ git commit --allow-empty -n -m "Initial commit."
 $ git subtree add  --prefix document https://github.com/detiuaveiro/ua-thesis-template.git master --squash;
-$ git subtree pull --prefix document https://github.com/detiuaveiro/ua-thesis-template.git --squash;
+$ git subtree pull --prefix document https://github.com/detiuaveiro/ua-thesis-template.git master --squash;
 ```
 
 - The first line will init a new repository for your thesis


### PR DESCRIPTION
Fixes the error "fatal: you must provide \<repository\> \<ref\>":

```txt
PS PhDThesis> git subtree pull --prefix document https://github.com/detiuaveiro/ua-thesis-template.git --squash;
fatal: you must provide <repository> <ref>
PS PhDThesis> git subtree pull  --prefix document https://github.com/detiuaveiro/ua-thesis-template.git master --squash;
From https://github.com/detiuaveiro/ua-thesis-template
 * branch            master     -> FETCH_HEAD
Subtree is already at commit 53d09a9e6d484c55a7a307d7e272ff744971c53
```