### PR TITLE
Fix hyperref page references

### DIFF
--- a/matter.tex
+++ b/matter.tex
@@ -235,6 +235,10 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \begin{document}
+
+% Fix the numbering scheme by having a ghost style for page numbering
+\pagenumbering{Alph}
+
 \ifthenelse{\equal{\useoverleaf}{0}}{}{\makecoverfile{}}%
 \includepdf[pages=-]{cover.pdf}
 


### PR DESCRIPTION
When you use any kind of page referencing, eg. when using `backref=true,` on the `biblatex` package, the PDF links to the wrong place.

**What currently happens:**

Reference says "(cit. on p. 1)." When clicking the "1", the PDF goes to the first page, instead of page 1.

**Why?**

The document starts with arab page numbering. `\includepdf[pages=-]{cover.pdf}` actually increments this counter, which is then reset after the ToCs. While the page numbering looks correct on the typeset document, the references are wrong.

**The fix**

The workaround works by setting `\pagenumbering{Alph}` first thing in the document. This makes so the cover pages are numbered in the `Alph` style (A, B, C, D, etc), preventing  the "corruption" on the arabic-style counter. This does show in the PDF document as "A (1/50)", but nothing is displayed cosmetically. 