### PR TITLE
Acronyms swapped

### DIFF
--- a/chapters/chapter1.tex
+++ b/chapters/chapter1.tex
@@ -1,5 +1,3 @@
-
-
 \chapter{Introdução}
 \label{chapter:introduction}
 
@@ -15,7 +13,7 @@ A memorable quote can also be used.
 
 Primeira e seguintes referências: \ac{h2o}, \ac{h2o}
 
-Plural, acrónimo expandido e curto: \acp{h2o}, \acs{h2o}, \acl{h2o}
+Plural, acrónimo expandido e curto: \acp{h2o}, \acl{h2o}, \acs{h2o}
 
 Com citação\footnote{Necessária entrada na bibliografia}: \ac{adsl}, \ac{adsl}
 


### PR DESCRIPTION
Hi!

This is just a minor fix. 

On the _chapter1.tex_ file, the order of the _\acl_ and _\acs_ acronyms was swapped.