### PR TITLE
Fixes for `make setup` and `make print`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ LATEXMK_FLAGS += -pdflatex="pdflatex -file-line-error --shell-escape %O %S"
 all: build
 
 setup:
-	@sudo apt install texlive-latex-base texlive-lang-portuguese texlive-lang-english biber texlive-latex-extra texlive-science python3-pygments python3-proselint pandoc imagemagick latexmk ghostscript 
+	@sudo apt install texlive-latex-base texlive-lang-portuguese texlive-lang-english biber texlive-latex-extra texlive-science python3-pygments python3-proselint pandoc imagemagick latexmk ghostscript lacheck chktex
 
 build: 
 	@mkdir -p ${OUT}/chapters

--- a/chapters/chapter1.tex
+++ b/chapters/chapter1.tex
@@ -1,4 +1,4 @@
-\chapter{Introdução}
+\chapter{Introdução}%
 \label{chapter:introduction}
 
 \begin{introduction}

--- a/scripts/simplify-colors.sh
+++ b/scripts/simplify-colors.sh
@@ -37,7 +37,10 @@ fi
 mkdir -p "$BUILD"
 rm -f "$BUILD"/*
 
-gs -q -sDEVICE=pdfwrite -dSAFER -o "$BUILD/%d-`basename $FILENAME .pdf`-split.pdf" "$FILENAME"
+gs -q -sDEVICE=pdfwrite -dSAFER \
+    --permit-file-write="$BUILD/" \
+    --permit-file-control="$BUILD/" \
+    -o "$BUILD/%d-`basename $FILENAME .pdf`-split.pdf" "$FILENAME"
 
 for i in `ls -v "$BUILD"/*-split.pdf`; do
     echo "$i"

--- a/scripts/simplify-colors.sh
+++ b/scripts/simplify-colors.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This script will convert all pages WITHOUT actual colors
 # but with grays expressed in color values to actual grays.


### PR DESCRIPTION
This PR includes the following fixes:
- The `make setup` command installs the necessary dependencies for `make lint`
- `chapter1.tex` includes a minor fix for a chktex error
- The shebang on `simplify-colors.sh` is improved to work on more linux distributions
- The GhostScript invocation on `simplify-colors.sh` is fixed for newer versions