### PR TITLE
Minor changes to some cover elements

### DIFF
--- a/uaThesisTemplate.sty
+++ b/uaThesisTemplate.sty
@@ -552,9 +552,9 @@ obten\c c\~ao do grau de {\ciDegreeTitle}
 \ifdefined \ciMAPProgram%
 no âmbito do Programa de Doutoramento
 \fi%
-em {\ciDegreeName}
+em {\ciDegreeName}%
 \ifdefined \ciMAPProgram%
- das Universidades do Minho, Aveiro e Porto (MAP-\ciMAPProgram)
+~das Universidades do Minho, Aveiro e Porto (MAP-\ciMAPProgram)%
 \fi%
 , realizada sob a orienta\c c\~ao cient\'ifica 
 \ifdefined \ciSupervisoraName%

--- a/uaThesisTemplate.sty
+++ b/uaThesisTemplate.sty
@@ -624,7 +624,7 @@ do {\ua@textA} {\ua@textB} da Universidade de Aveiro\dolistloop{\ciSupervisorMem
 \ifdefined \ciAIUse
 \TitlePage
   \vspace*{55mm}
-  \SECTION{\textbf{reconhecimento do uso de\newline ferramentas de AI}}
+  \SECTION{\textbf{reconhecimento do uso de\newline ferramentas IA~/\newline acknowledgement of use of\newline AI tools}}
        {\textbf{Reconhecimento do uso de tecnologias e ferramentas de Inteligência Artificial (IA) generativa, softwares e outras ferramentas de apoio.} \newline \ciAIUse}
 
 \EndTitlePage


### PR DESCRIPTION
This is a small PR that removes an incorrect space before comma (sorry, my OCD can't handle it 🙃) on the second page, next to the degree name.

I've also taken the opportunity to fix the title of the new section on acknowledging the use of AI, in accordance with the guidelines (portuguese short form for "AI" is "IA"), and also to add the english version of that same title, in line with the other sections that also have it (jury, acknowledgements, ...).

|  | Before | After |
|  --: | :-: | :-: |
| Space after degree name | ![0_before](https://github.com/user-attachments/assets/8b81caff-a4d2-4409-a426-bfc21683f9e1) |  ![0_after](https://github.com/user-attachments/assets/bd23bdd9-1be1-4616-aff5-af1df7fddc04)  |
| Space after degree name (w/ MAP Doctoral program) | ![1_before](https://github.com/user-attachments/assets/580d9770-a564-4ef8-868f-84678bc24a8b) | ![1_after](https://github.com/user-attachments/assets/71166297-ea61-464b-a9c3-383d84776350) |
| AI acknowledgement section title | ![3_before](https://github.com/user-attachments/assets/63b3004d-482b-4a3e-95c5-6f45be812731) | ![3_after](https://github.com/user-attachments/assets/c19e0253-18a1-4a9c-a157-9543143889bd) |