### PR TITLE
Changing `make clean` to revert to initial template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ ebook: build
 
 clean: 
 	@echo "Deleting all files except PDFs in the build directory"
-	@find "${OUT}" -type f ! -name '*.pdf' -delete
-	@find "${OUT}"/* -type d -delete
+	@find "${OUT}" -type f ! \( -name '*.pdf' -o -name '.gitkeep' \) -delete
+	@find "${OUT}"/* -empty -type d -delete
 
 clean_aux:
 	@echo "Deleting AUX files in the build directory"


### PR DESCRIPTION
It seems counterproductive the state after `make clean` is not the same as when using the template for the first time.
This could lead to a different experience for users that never preformed a `make clean` action versus the ones that did.
I'd suggest leaving the forced deletion of all files in OUT directory to `make cleanall`