### PR TITLE
Removing extra space before a comma

### DIFF
--- a/uaThesisTemplate.sty
+++ b/uaThesisTemplate.sty
@@ -552,9 +552,9 @@ obten\c c\~ao do grau de {\ciDegreeTitle}
 \ifdefined \ciMAPProgram%
 no âmbito do Programa de Doutoramento
 \fi%
-em {\ciDegreeName}
+em {\ciDegreeName}%
 \ifdefined \ciMAPProgram%
- das Universidades do Minho, Aveiro e Porto (MAP-\ciMAPProgram)
+\ das Universidades do Minho, Aveiro e Porto (MAP-\ciMAPProgram)%
 \fi%
 , realizada sob a orienta\c c\~ao cient\'ifica 
 \ifdefined \ciSupervisoraName%


### PR DESCRIPTION
Since line 559 starts with a "," it seems it's necessary to prevent the previous line from creating a space before it