### PR TITLE
Restore original content in matter.tex and removes warnings 

### DIFF
--- a/matter.tex
+++ b/matter.tex
@@ -9,7 +9,6 @@
 \documentclass[11pt,a4paper,oneside,onecolumn]{memoir}
 
 \listfiles
-\fixpdflayout
 
 \usepackage[utf8]{inputenc}
 
@@ -118,7 +117,7 @@
 
 % Setup bibliography with Biber using IEEE style for proper UTF-8 support
 \usepackage[backend=biber, style=ieee, sorting=none, natbib=true, mincitenames=1, maxcitenames=2]{biblatex}
-\bibliography{bib/references.bib}
+\bibliography{bib/references.bib, bib/rfc.bib}
 
 % Use acronyms
 \usepackage[printonlyused]{acronym} % For acronyms
@@ -141,7 +140,7 @@
 %\usetikzlibrary{arrows,shadows,trees,shapes,decorations,automata,backgrounds,petri,mindmap} % for pgf-umlsd
 
 % Package to master SI units
-\usepackage[detect-weight=true, binary-units=true]{siunitx}
+\usepackage[detect-weight=true]{siunitx}
 % For Electric Circuits
 %\sisetup{load-configurations = binary}
 


### PR DESCRIPTION
Restore original content in matter.tex and removes warnings related to deprecated functions

The \fixpdflayout was deprecated in 2018. Newer compilers rendered this feature unusable. Mailing-list anouncement: https://ctan.org/ctan-ann/id/mailman.3145.1523048517.5100.ctan-ann@ctan.org?lang=en


The siunitx binary-units option has been removed. More information can be found  here: https://www.tug.org/docs/latex/siunitx/siunitx.pdf

Furthermore, this PR removes warnings related to rfc44, one of the references used in the template, that is currently not used.